### PR TITLE
Generic slurm configuration

### DIFF
--- a/coupledmodeldriver/generate/adcirc/generate.py
+++ b/coupledmodeldriver/generate/adcirc/generate.py
@@ -91,6 +91,7 @@ def generate_adcirc_configuration(
     platform = base_configuration['modeldriver']['platform']
 
     job_duration = base_configuration['slurm']['job_duration']
+    slurm_account = base_configuration['slurm']['account']
     partition = base_configuration['slurm']['partition']
     email_type = base_configuration['slurm']['email_type']
     email_address = base_configuration['slurm']['email_address']
@@ -112,7 +113,8 @@ def generate_adcirc_configuration(
 
     run_phase = 'HOTSTART' if do_spinup else 'COLDSTART'
 
-    slurm_account = platform.value['slurm_account']
+    if slurm_account is None:
+        slurm_account = platform.value['slurm_account']
 
     ensemble_run_script_filename = output_directory / f'run_{platform.name.lower()}.sh'
     ensemble_cleanup_script_filename = output_directory / f'cleanup.sh'

--- a/coupledmodeldriver/platforms.py
+++ b/coupledmodeldriver/platforms.py
@@ -34,3 +34,11 @@ class Platform(Enum):
         'slurm_account': None,
         'default_partition': None,
     }
+    SLURM = {
+        'source_filename': None,
+        'processors_per_node': 36,
+        'launcher': 'srun',
+        'uses_slurm': True,
+        'slurm_account': None,
+        'default_partition': None,
+    }


### PR DESCRIPTION
Information on default account name and partition (and other information) for slurm job execution was located in the `platforms.py`.

That is fine but the account in `configure_slurm.json` was being ignored if we wish to overwrite whatever is in `platforms.py`.

I set up a generic slurm platform and then enabled the account and partition to be read in from the `configure_slurm.json` correctly. 

We could also utilize the parallel pool to get the number of processors per core information automatically too. 