### PR TITLE
Removing python 3.7 support due to xarray

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,11 +45,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
         # due to cfdm dependency python 3.10 cannot be supported
-        # macos python 3.7 results in segmentation error
-        python-version: [ '3.7', '3.8', '3.9' ]
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: [ '3.8', '3.9' ]
     steps:
       - name: clone repository
         uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = 'poetry.core.masonry.api'
 enable = true
 
 [tool.poetry.dependencies]
-python = '>=3.7,<3.10'
+python = '>=3.8,<3.10'
 adcircpy = '^1.2.1'
 file-read-backwards = '*'
 nemspy = '>=1.0.4'


### PR DESCRIPTION
Since the release of `importlib-metadata` version `5.0` the older (e.g. `0.20.2`) versions of `xarray` that supported `Python 3.7` cannot be used. Since those versions are pre-release, it's unlikely that they get fixed. An example of the issue caused by older `xarray` is:

```
ensembleperturbation/parsing/adcirc.py:704: in combine_outputs
    directory=runs_directory, file_outputs=file_data_variables, parallel=parallel,
ensembleperturbation/parsing/adcirc.py:6[47](https://github.com/noaa-ocs-modeling/EnsemblePerturbation/actions/runs/3575121349/jobs/6011281573#step:6:48): in parse_adcirc_outputs
    directory, variables=output_class.variables, parallel=parallel,
ensembleperturbation/parsing/adcirc.py:92: in read_directory
    filenames[0], drop_variables=drop_variables
/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/xarray/backends/api.py:479: in open_dataset
    engine = plugins.guess_engine(filename_or_obj)
/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/xarray/backends/plugins.py:110: in guess_engine
    engines = list_engines()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    @functools.lru_cache(maxsize=1)
    def list_engines():
>       entrypoints = entry_points().get("xarray.backends", ())
E       AttributeError: 'EntryPoints' object has no attribute 'get'
```