### PR TITLE
Fix the CI error for publishing CoupledModelDriver after removing Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
         uses: abatilo/actions-poetry@v2.2.0
       - name: install Dunamai
         run: pip install dunamai
+      - name: set python version
+        run: poetry env use 3.9
       - name: extract version from VCS
         run: poetry version $(dunamai from any)
       - name: build wheel and source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,24 +1,40 @@
 name: build
 
 on:
+  push:
   release:
     types:
       - published
 
 jobs:
-  publish:
-    name: publish package to PyPI
+  build:
+    name: build package
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@v2
       - name: install Poetry
-        uses: abatilo/actions-poetry@v2.1.3
+        uses: abatilo/actions-poetry@v2.2.0
       - name: install Dunamai
         run: pip install dunamai
       - name: extract version from VCS
         run: poetry version $(dunamai from any)
       - name: build wheel and source
         run: poetry build
+      - name: save builds
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: ./dist
+  publish:
+      if: github.event_name == 'release'
+      name: publish package to PyPI
+      runs-on: ubuntu-latest
+      steps:
+      - name: retrieve wheel(s) and source
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: dist
       - name: upload wheel and source
         run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
       - name: install Poetry
         uses: abatilo/actions-poetry@v2.2.0
       - name: install Dunamai
         run: pip install dunamai
-      - name: set python version
-        run: poetry env use 3.9
       - name: extract version from VCS
         run: poetry version $(dunamai from any)
       - name: build wheel and source
         run: poetry build
       - name: save builds
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build
           path: ./dist
@@ -34,7 +36,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - name: retrieve wheel(s) and source
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build
           path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = 'poetry.core.masonry.api'
 enable = true
 
 [tool.poetry.dependencies]
-python = '>=3.8,<3.10'
+python = '>= 3.8, < 3.10'
 adcircpy = '^1.2.1'
 file-read-backwards = '*'
 nemspy = '>=1.0.4'


### PR DESCRIPTION
After removing Python `3.7` from the supported list, CI action for publishing started running into issues.