### PR TITLE
Add the missing dependency of publish on build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           name: build
           path: ./dist
   publish:
+      needs: build
       if: github.event_name == 'release'
       name: publish package to PyPI
       runs-on: ubuntu-latest


### PR DESCRIPTION
The publish action needs to be executed when the build action is completed, so that the build packages are available. This dependency is missing in the job definition