### PR TITLE
Add missing package for publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,7 @@ jobs:
         with:
           name: build
           path: dist
+      - name: install Poetry
+        uses: abatilo/actions-poetry@v2.2.0          
       - name: upload wheel and source
         run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
After separating build and publish step, the publish job didn't have `poetry` installed.