### PR TITLE
`pyproject.toml` needed for `poetry publish`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           name: build
           path: dist
+      - name: checkout repository
+        uses: actions/checkout@v3
       - name: install Poetry
         uses: abatilo/actions-poetry@v2.2.0          
       - name: upload wheel and source


### PR DESCRIPTION
In the `publish` step the repo was not checkout!