### PR TITLE
Stormevent version dependency update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ fiona = '*'  # improper upstream dependency setup
 nemspy = '>=1.0.4'
 numpy = '*'
 pyproj = '*'
-stormevents = '>=2.3.2' # tests results based on speed fix
+stormevents = '>=2.2.5, != 2.3.0, != 2.3.1' # tests results based on speed fix
 typepigeon = '^1.0.3'
 isort = { version = '*', optional = true }
 oitnb = { version = '*', optional = true }


### PR DESCRIPTION
We'd like to be able to use `stormevents` with speed and quadrant fix, but without the rmax forecast added. That's why a new version [`2.2.5`](https://github.com/oceanmodeling/StormEvents/releases/tag/v2.2.5) is released for `stormevents` and this PR is going to make that available as an option for `couplemodeldriver`